### PR TITLE
docs: outline cook project adaptation plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-"# My Project: Cookwhat" 
+# Cookwhat: YouTube Overseas Edition
+
+This repository is prepared to replicate and adapt the open-source project [`YunYouJun/cook`](https://github.com/YunYouJun/cook) for an overseas audience whose primary content source is YouTube videos.
+
+## Repository Initialization Checklist
+
+1. **Create a new Git repository** (if you have not already) by running `git init` inside the project directory.
+2. **Configure Git user information** so your commits have the correct author metadata:
+   ```bash
+   git config user.name "Your Name"
+   git config user.email "your.email@example.com"
+   ```
+3. **Add the initial project files** (for example this README, a license, and any starter configuration) using `git add .`.
+4. **Create the first commit** to establish the repository history:
+   ```bash
+   git commit -m "chore: initialize project"
+   ```
+5. **Connect to GitHub** by creating a new remote repository and adding it as the remote:
+   ```bash
+   git remote add origin git@github.com:YourAccount/cookwhat.git
+   ```
+6. **Push the initial commit** to GitHub:
+   ```bash
+   git push -u origin main
+   ```
+
+These steps ensure the repository is properly initialized before you start building features.
+
+## Can the `YunYouJun/cook` Project Be Replicated?
+
+Yes—`YunYouJun/cook` is distributed under the [MIT License](https://github.com/YunYouJun/cook/blob/main/LICENSE), which explicitly permits copying, modifying, and distributing the software, including for commercial purposes, as long as the license terms are followed. When adapting the project:
+
+- **Retain the MIT license notice** in your project.
+- **Document your modifications** so downstream users know what changed.
+- **Respect trademark and branding**; avoid implying endorsement by the original author unless granted permission.
+
+## Adapting for YouTube Content and Overseas Markets
+
+To tailor the project for YouTube-sourced content aimed at an international audience, consider the following roadmap:
+
+1. **Content ingestion**: Build a pipeline to fetch metadata and statistics from the YouTube Data API (ensure you comply with YouTube Terms of Service).
+2. **Localization**: Provide multi-language support (English, Spanish, etc.) with translated ingredient names and instructions.
+3. **Recipe data model**: Extend the data schema to include video links, timestamps for steps, and subtitles/closed captions.
+4. **UI/UX adjustments**: Optimize layouts for video-first presentation, including responsive players and call-to-action overlays.
+5. **SEO and sharing**: Implement structured data (JSON-LD) for recipes and rich previews tailored for overseas search engines and social media.
+6. **Monetization readiness**: Prepare integration points for affiliate links or sponsored content, following regional regulations.
+7. **Deployment**: Set up CI/CD workflows for global hosting providers (e.g., Vercel, Netlify) with CDN-backed asset delivery.
+
+## Next Steps
+
+- Add project scaffolding (frontend framework, build tooling, etc.).
+- Document API usage guidelines and rate limits for YouTube.
+- Create issue templates and contribution guidelines to encourage collaboration.
+
+With this plan, you can confidently replicate the original open-source project while adapting it to YouTube-based content for an overseas market.


### PR DESCRIPTION
## Summary
- expand the README with a checklist for initializing the repository
- document the MIT licensing terms that allow adapting YunYouJun/cook
- outline a roadmap for repurposing the project around YouTube content for overseas users

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d675fe4430832e8aaeb26be257f2bb